### PR TITLE
Front/feat/home-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.52.2",
+        "react-infinite-scroll-component": "^6.1.0",
         "react-use-gesture": "^9.1.3",
         "relative-time": "^1.0.0",
         "swiper": "^11.1.9",
@@ -6362,6 +6363,18 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-infinite-scroll-component": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz",
+      "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "throttle-debounce": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7366,6 +7379,15 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tiny-inflate": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.52.2",
+    "react-infinite-scroll-component": "^6.1.0",
     "react-use-gesture": "^9.1.3",
     "relative-time": "^1.0.0",
     "swiper": "^11.1.9",

--- a/prisma/seed/seed.ts
+++ b/prisma/seed/seed.ts
@@ -14,7 +14,7 @@ const main = async () => {
   })));
 
   // Seed Careers
-  const {career: careers} = await seed.career((x) => x(15, (c) => ({
+  const { career: careers } = await seed.career((x) => x(15, (c) => ({
     name: faker.person.jobTitle(),
     website: faker.internet.url(),
     study_plan_url: faker.internet.url(),
@@ -26,23 +26,25 @@ const main = async () => {
   })));
 
   // Seed Users
-  const {user: users} = await seed.user((x) => x(20, (u) => ({
+  const { user: users } = await seed.user((x) => x(20, (u) => ({
     email: faker.internet.email(),
+    name: faker.internet.userName(),
     password: bcryptjs.hashSync('password', 10),
     role: faker.helpers.arrayElement(['ASPIRANT', 'STUDENT', 'ADMIN']),
     image: u.index % 2 === 0 ? null : "https://res.cloudinary.com/dxdme71no/image/upload/v1722901389/hufhpfqpgmwr4p5kj1ja.jpg",
   })));
 
   // Seed Testimonies
-  const {testimony: testimonies} = await seed.testimony((x) => x(30, (t) => ({
+  const { testimony: testimonies } = await seed.testimony((x) => x(30, (t) => ({
     title: faker.lorem.sentence(),
     content: faker.lorem.paragraphs(),
     userId: faker.helpers.arrayElement(users).id,
     careerId: faker.helpers.arrayElement(careers).id,
+    createdAt: faker.date.past(),
   })));
 
   // Seed Questions
-  const {question: questions} = await seed.question((x) => x(25, (q) => ({
+  const { question: questions } = await seed.question((x) => x(25, (q) => ({
     title: faker.lorem.sentence(),
     content: faker.lorem.paragraphs(),
     userId: faker.helpers.arrayElement(users).id,

--- a/src/app/(auth)/(app-bar)/home/page.tsx
+++ b/src/app/(auth)/(app-bar)/home/page.tsx
@@ -1,19 +1,21 @@
-import ImageForm from "@/shared/components/ImageForm";
+import paginateTestimonies from "@/shared/actions/paginateTestimonies";
+import { TestimoniesList } from "@/shared/components/Testimony/TestimoniesList/TestimoniesList";
 import { Metadata } from "next";
-import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Home Page",
   description: "Home page",
 };
 
-export default function HomePage() {
+export default async function HomePage() {
+
+  const initTestimonies = await paginateTestimonies(3, 0);
+
   return (
-    <>
-      <Link href="/user">
-        User page
-      </Link>
-      <ImageForm />
-    </>
+    <div>
+      <TestimoniesList
+        initTestimonies={initTestimonies}
+      />
+    </div>
   );
 }

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,9 +1,11 @@
 import { EndMessage } from "@/shared/components/Testimony/TestimoniesList/EndMessage";
+import { Refresh } from "@/shared/components/Testimony/TestimoniesList/Refresh";
 import Testimony from "@/shared/components/Testimony/Testimony";
 
 export default function Page() {
   return (
     <div className="flex flex-col items-center">
+      <Refresh/>
       <Testimony
         userName="Roberto Pedragonosa"
         userPhotoUrl="/svgs/user.svg"

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,3 +1,4 @@
+import { EndMessage } from "@/shared/components/Testimony/TestimoniesList/EndMessage";
 import Testimony from "@/shared/components/Testimony/Testimony";
 
 export default function Page() {
@@ -13,6 +14,7 @@ export default function Page() {
         imageUrls={[]}
         createdAt={new Date()}
       />
+      <EndMessage />
       <Testimony
         userName="Roberto Pedragonosa"
         userPhotoUrl="/svgs/user.svg"

--- a/src/shared/actions/getTestimonyData.ts
+++ b/src/shared/actions/getTestimonyData.ts
@@ -1,15 +1,15 @@
-"use server";
+"use server"
 
 import prisma from "@/lib/prisma";
 
-export default async function paginateTestimonies(take: number, skip: number) {
-  return prisma.testimony.findMany({
+export default async function getTestimonyData(testimonyId: string) {
+
+  return await prisma.testimony.findUnique({
+    where: { id: testimonyId },
     include: {
       user: { select: { name: true, image: true, } },
       career: { select: { name: true } },
       _count: { select: { Comments: true, TestimonyLike: true } },
-    },
-    skip,
-    take
-  })
+    }
+  });
 }

--- a/src/shared/actions/paginateTestimonies.ts
+++ b/src/shared/actions/paginateTestimonies.ts
@@ -3,13 +3,15 @@
 import prisma from "@/lib/prisma";
 
 export default async function paginateTestimonies(take: number, skip: number) {
-  return prisma.testimony.findMany({
+  const testimonies = await prisma.testimony.findMany({
     include: {
       user: { select: { name: true, image: true, } },
       career: { select: { name: true } },
       _count: { select: { Comments: true, TestimonyLike: true } },
     },
     skip,
-    take
-  })
+    take,
+  });
+
+  return testimonies.sort(() => Math.random() - 0.5)
 }

--- a/src/shared/actions/paginateTestimonies.ts
+++ b/src/shared/actions/paginateTestimonies.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+
+export default async function paginateTestimonies(take: number, skip: number) {
+  return prisma.testimony.findMany({
+    skip,
+    take
+  })
+}

--- a/src/shared/components/AppBar.tsx
+++ b/src/shared/components/AppBar.tsx
@@ -11,7 +11,7 @@ export const AppBar = async () => {
   const user: User | undefined = session?.user;
 
   return (
-    <div className="flex justify-between items-center py-2 px-4">
+    <div className="sticky top-0 z-20 bg-white flex justify-between items-center py-2 px-4">
       <UserAvatar
         photoUrl={user?.image || ""}
         height={32}

--- a/src/shared/components/Testimony/TestimoniesList/EndMessage.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/EndMessage.tsx
@@ -1,0 +1,8 @@
+
+export const EndMessage = () => {
+  return (
+    <div className="flex flex-col items-center justify-center h-20 p-4 pt-0">
+      <h3 className="font-semibold">¡Es todo por hoy!</h3>
+    </div>
+  )
+}

--- a/src/shared/components/Testimony/TestimoniesList/Loader.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/Loader.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export const Loader = () => {
+  return (
+    <div>Loader</div>
+  )
+}

--- a/src/shared/components/Testimony/TestimoniesList/Loader.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/Loader.tsx
@@ -1,7 +1,0 @@
-import React from 'react'
-
-export const Loader = () => {
-  return (
-    <div>Loader</div>
-  )
-}

--- a/src/shared/components/Testimony/TestimoniesList/Loading.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/Loading.tsx
@@ -1,0 +1,32 @@
+import UserAvatar from '@/features/user/components/UserAvatar'
+import React from 'react'
+import SkeletonText from '../../Skeletons/SkeletonText'
+
+export const Loading = () => {
+  return (
+    <div>
+      <div className="h-[155px] overflow-hidden max-w-lg bg-white rounded-t-lg p-4  relative border border-gray-200">
+        <div className="mt-10 xs:mt-4">
+          <UserAvatar
+            width={48}
+            height={48}
+            showName
+          />
+          <div className="ml-16">
+            <div className="mt-2">
+              <p className="text-gray-500">
+                <SkeletonText width="100px" height="1rem" />
+              </p>
+            </div>
+            <div className="text-gray-500 mt-2 font-semibold">
+              <SkeletonText width="80px" height="1rem" />
+            </div>
+            <div className="mt-4">
+              <SkeletonText width="100%" height="1rem" className="mb-2" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/shared/components/Testimony/TestimoniesList/Loading.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/Loading.tsx
@@ -1,5 +1,4 @@
 import UserAvatar from '@/features/user/components/UserAvatar'
-import React from 'react'
 import SkeletonText from '../../Skeletons/SkeletonText'
 
 export const Loading = () => {

--- a/src/shared/components/Testimony/TestimoniesList/Refresh.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/Refresh.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export const Refresh = () => {
+  return (
+    <div className="z-10 w-full flex justify-center items-center h-16 bg-green text-white">
+        <span className="flex items-center">
+          <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+          </svg>
+        </span>
+    </div>
+  )
+}

--- a/src/shared/components/Testimony/TestimoniesList/ReleaseRefresh.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/ReleaseRefresh.tsx
@@ -1,0 +1,9 @@
+export const ReleaseRefresh = () => {
+  return (
+    <div className="z-10 w-full flex justify-center items-center h-16 bg-green text-white">
+        <span className="flex items-center">
+          Suelta para refrescar
+        </span>
+    </div>
+  )
+}

--- a/src/shared/components/Testimony/TestimoniesList/TestimoniesList.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/TestimoniesList.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { useState } from "react";
-import { type Testimony } from "@prisma/client";
 import InfiniteScroll from "react-infinite-scroll-component";
 
+import { TestimonyWithRelations } from "@/shared/types/TestimonyWithRelations";
 import paginateTestimony from "@/shared/actions/paginateTestimonies";
-import { Loading } from "./Loading";
 import TestimonyComponent from "../Testimony";
+import { Loading } from "./Loading";
 
 interface Props {
-  initTestimonies: Testimony[];
+  initTestimonies: TestimonyWithRelations[];
 }
 
 export const TestimoniesList = ({ initTestimonies }: Props) => {
@@ -20,23 +20,28 @@ export const TestimoniesList = ({ initTestimonies }: Props) => {
     <div className="flex flex-col items-center">
       <InfiniteScroll
         hasMore
-        next={() => {
-          setTimeout(async () => {
-            const newTestimonies = await paginateTestimony(3, testimonies.length)
-            setTestimonies(testimonies.concat(...newTestimonies));
-          }, 3000);
+        next={async () => {
+          const newTestimonies = await paginateTestimony(3, testimonies.length)
+          setTestimonies(testimonies.concat(...newTestimonies));
         }}
         loader={<Loading />}
         dataLength={testimonies.length}
       >
-        {testimonies.map((testimony: Testimony) => (
-          <TestimonyComponent
-            key={testimony.id}
-            createdAt={testimony.createdAt}
-            content={testimony.content}
-          />
-        ))}
+        {testimonies.map((testimony) => {
+          return (
+            <TestimonyComponent
+              key={testimony.id}
+              createdAt={testimony.createdAt}
+              content={testimony.content}
+              commentCount={testimony._count.Comments}
+              heartCount={testimony._count.TestimonyLike}
+              career={testimony.career.name}
+              userName={testimony.user.name ?? "no name"}
+              userPhotoUrl={testimony.user.image ?? ""}
+            />
+          )
+        })}
       </InfiniteScroll>
-    </div>
+    </div >
   )
 }

--- a/src/shared/components/Testimony/TestimoniesList/TestimoniesList.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/TestimoniesList.tsx
@@ -5,7 +5,8 @@ import { type Testimony } from "@prisma/client";
 import InfiniteScroll from "react-infinite-scroll-component";
 
 import paginateTestimony from "@/shared/actions/paginateTestimonies";
-import { Loader } from "./Loader";
+import { Loading } from "./Loading";
+import TestimonyComponent from "../Testimony";
 
 interface Props {
   initTestimonies: Testimony[];
@@ -16,22 +17,26 @@ export const TestimoniesList = ({ initTestimonies }: Props) => {
   const [testimonies, setTestimonies] = useState(initTestimonies)
 
   return (
-    <InfiniteScroll
-      hasMore
-      next={() => {
-        setTimeout(async () => {
-          const newTestimonies = await paginateTestimony(3, testimonies.length)
-          setTestimonies(testimonies.concat(...newTestimonies));
-        }, 3000);
-      }}
-      loader={<Loader/>}
-      dataLength={testimonies.length}
-    >
-      {
-        testimonies.map((testimony: Testimony) => (
-          <div className="h-[500px] m-2 bg-slate-400" key={testimony.id}>{testimony.title}</div>
-        ))
-      }
-    </InfiniteScroll>
+    <div className="flex flex-col items-center">
+      <InfiniteScroll
+        hasMore
+        next={() => {
+          setTimeout(async () => {
+            const newTestimonies = await paginateTestimony(3, testimonies.length)
+            setTestimonies(testimonies.concat(...newTestimonies));
+          }, 3000);
+        }}
+        loader={<Loading />}
+        dataLength={testimonies.length}
+      >
+        {testimonies.map((testimony: Testimony) => (
+          <TestimonyComponent
+            key={testimony.id}
+            createdAt={testimony.createdAt}
+            content={testimony.content}
+          />
+        ))}
+      </InfiniteScroll>
+    </div>
   )
 }

--- a/src/shared/components/Testimony/TestimoniesList/TestimoniesList.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/TestimoniesList.tsx
@@ -7,6 +7,7 @@ import { TestimonyWithRelations } from "@/shared/types/TestimonyWithRelations";
 import paginateTestimony from "@/shared/actions/paginateTestimonies";
 import TestimonyComponent from "../Testimony";
 import { Loading } from "./Loading";
+import { EndMessage } from "./EndMessage";
 
 interface Props {
   initTestimonies: TestimonyWithRelations[];
@@ -15,16 +16,19 @@ interface Props {
 export const TestimoniesList = ({ initTestimonies }: Props) => {
 
   const [testimonies, setTestimonies] = useState(initTestimonies)
+  const [hasMore, setHasMore] = useState(true);
 
   return (
     <div className="flex flex-col items-center">
       <InfiniteScroll
-        hasMore
+        hasMore={hasMore}
         next={async () => {
           const newTestimonies = await paginateTestimony(3, testimonies.length)
+          if (!newTestimonies.length) setHasMore(false);
           setTestimonies(testimonies.concat(...newTestimonies));
         }}
         loader={<Loading />}
+        endMessage={<EndMessage />}
         dataLength={testimonies.length}
       >
         {testimonies.map((testimony) => {

--- a/src/shared/components/Testimony/TestimoniesList/TestimoniesList.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/TestimoniesList.tsx
@@ -8,6 +8,8 @@ import paginateTestimony from "@/shared/actions/paginateTestimonies";
 import TestimonyComponent from "../Testimony";
 import { Loading } from "./Loading";
 import { EndMessage } from "./EndMessage";
+import { Refresh } from "./Refresh";
+import { ReleaseRefresh } from "./ReleaseRefresh";
 
 interface Props {
   initTestimonies: TestimonyWithRelations[];
@@ -22,14 +24,21 @@ export const TestimoniesList = ({ initTestimonies }: Props) => {
     <div className="flex flex-col items-center">
       <InfiniteScroll
         hasMore={hasMore}
+        dataLength={testimonies.length}
+        pullDownToRefresh
+        pullDownToRefreshContent={<Refresh />}
+        releaseToRefreshContent={<ReleaseRefresh />}
+        pullDownToRefreshThreshold={100}
+        loader={<Loading />}
+        endMessage={<EndMessage />}
+        refreshFunction={async () => {
+          setTestimonies(await paginateTestimony(3, 0));
+        }}
         next={async () => {
           const newTestimonies = await paginateTestimony(3, testimonies.length)
           if (!newTestimonies.length) setHasMore(false);
           setTestimonies(testimonies.concat(...newTestimonies));
         }}
-        loader={<Loading />}
-        endMessage={<EndMessage />}
-        dataLength={testimonies.length}
       >
         {testimonies.map((testimony) => {
           return (

--- a/src/shared/components/Testimony/TestimoniesList/TestimoniesList.tsx
+++ b/src/shared/components/Testimony/TestimoniesList/TestimoniesList.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { type Testimony } from "@prisma/client";
+import InfiniteScroll from "react-infinite-scroll-component";
+
+import paginateTestimony from "@/shared/actions/paginateTestimonies";
+import { Loader } from "./Loader";
+
+interface Props {
+  initTestimonies: Testimony[];
+}
+
+export const TestimoniesList = ({ initTestimonies }: Props) => {
+
+  const [testimonies, setTestimonies] = useState(initTestimonies)
+
+  return (
+    <InfiniteScroll
+      hasMore
+      next={() => {
+        setTimeout(async () => {
+          const newTestimonies = await paginateTestimony(3, testimonies.length)
+          setTestimonies(testimonies.concat(...newTestimonies));
+        }, 3000);
+      }}
+      loader={<Loader/>}
+      dataLength={testimonies.length}
+    >
+      {
+        testimonies.map((testimony: Testimony) => (
+          <div className="h-[500px] m-2 bg-slate-400" key={testimony.id}>{testimony.title}</div>
+        ))
+      }
+    </InfiniteScroll>
+  )
+}

--- a/src/shared/components/Testimony/Testimony.tsx
+++ b/src/shared/components/Testimony/Testimony.tsx
@@ -56,6 +56,7 @@ export default function Testimony({
           photoUrl={userPhotoUrl}
           width={48}
           height={48}
+          showName
         />
         <div className="ml-16">
           <div className="mt-2">

--- a/src/shared/types/TestimonyWithRelations.ts
+++ b/src/shared/types/TestimonyWithRelations.ts
@@ -1,0 +1,9 @@
+import { Prisma } from '@prisma/client'
+
+export type TestimonyWithRelations = Prisma.TestimonyGetPayload<{
+  include: {
+    user: { select: { name: true, image: true } }
+    career: { select: { name: true } }
+    _count: { select: { Comments: true, TestimonyLike: true } }
+  }
+}>


### PR DESCRIPTION
## Qué se hizo?
- se agregó la vista de home
  - muestra todos los testimonios disponibles
- se agregó el componente TestimoniesList
  - se agregó un scroll infinito que optimiza las peticiones a backend al renderizar
  - se agregó el gestos scrollToRefresh 
  - se agregó ui de loading y endMessage

El componente TestimoniesList es completamente reutilizable con cualquier lista de testimonios
En las herramientas de desarrollo simula una conexión 4g lenta para que puedas ver todas las funcionalidades del componente

## ScreenShots
[home-page-demo.webm](https://github.com/user-attachments/assets/354846a4-1acb-4c68-ac0e-57282d4f8467)

