### PR TITLE
Fix/#112/user testimonies in his own career

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,15 +3,17 @@ const nextConfig = {
   images: {
     remotePatterns: [
       {
-        hostname: 'lh3.googleusercontent.com',
-        protocol: 'https',
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        pathname: "/**",
       },
       {
-        hostname: 'res.cloudinary.com',
-        protocol: 'https',
-      }
-    ]
-  }
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/shared/actions/User/getUserData.ts
+++ b/src/shared/actions/User/getUserData.ts
@@ -17,6 +17,7 @@ export async function getUserData(userId: string) {
           select: {
             id: true,
             name: true,
+            slug: true,
           },
         },
         semester: true,

--- a/src/shared/components/PostForm/NewPost.tsx
+++ b/src/shared/components/PostForm/NewPost.tsx
@@ -1,13 +1,22 @@
-// src/shared/components/PostForm/NewPost.tsx
 "use client";
 import { useState, useEffect } from "react";
 import { useMediaQuery } from "@react-hook/media-query";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 
 import { PostCard } from "./PostCard";
 import PostForm from "./PostForm";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import {
   Drawer,
   DrawerTrigger,
@@ -23,6 +32,8 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { getCareerId } from "@/shared/actions/Careers/getCareerId";
+import { getUserData } from "@/shared/actions/User/getUserData";
+import { canCreatePost } from "@/utils/postRestrictions";
 
 interface NewPostProps {
   careerSlug: string;
@@ -30,8 +41,13 @@ interface NewPostProps {
 
 export default function NewPost({ careerSlug }: NewPostProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [showAlert, setShowAlert] = useState(false);
+  const [alertType, setAlertType] = useState<"student" | "aspirant" | null>(
+    null
+  );
   const isDesktop = useMediaQuery("(min-width: 768px)");
   const pathname = usePathname();
+  const router = useRouter();
   const { data: session } = useSession();
   const [postType, setPostType] = useState<"TESTIMONY" | "QUESTION">(
     "TESTIMONY"
@@ -53,6 +69,61 @@ export default function NewPost({ careerSlug }: NewPostProps) {
     fetchCareerId();
   }, [pathname, careerSlug]);
 
+  const handlePostCardClick = async () => {
+    if (!session?.user) return;
+
+    try {
+      const { allowed, alertType: restrictionAlertType } = await canCreatePost(
+        session,
+        postType,
+        careerSlug
+      );
+
+      if (!allowed && restrictionAlertType) {
+        setAlertType(restrictionAlertType);
+        setShowAlert(true);
+        return;
+      }
+
+      setIsOpen(true);
+    } catch (error) {
+      console.error("Error checking post creation permissions:", error);
+    }
+  };
+
+  const handleAlertAction = async (
+    action: "myCareer" | "addQuestion" | "close"
+  ) => {
+    setShowAlert(false);
+
+    switch (action) {
+      case "myCareer":
+        if (session?.user?.id) {
+          try {
+            const userData = await getUserData(session.user.id);
+
+            if (userData.career) {
+              router.push(`/career/${userData.career.slug}/forum/testimonies`);
+            } else {
+              console.error("No career found for user");
+            }
+          } catch (error) {
+            console.error("Error fetching user data:", error);
+          }
+        }
+        break;
+      case "addQuestion":
+        router.push(`/career/${careerSlug}/forum/questions`);
+        // Add a small delay to ensure navigation completes before opening
+        setTimeout(() => {
+          setIsOpen(true);
+        }, 100);
+        break;
+      case "close":
+        break;
+    }
+  };
+
   const content = (
     <PostForm
       authorId={session?.user?.id || ""}
@@ -63,48 +134,123 @@ export default function NewPost({ careerSlug }: NewPostProps) {
     />
   );
 
+  const renderAlert = () => {
+    switch (alertType) {
+      case "student":
+        return (
+          <AlertDialog open={showAlert} onOpenChange={setShowAlert}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Publicación no permitida</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Los testimonios solo pueden publicarse en tu propia carrera.
+                  ¿Quieres ir a tu carrera o publicar una pregunta en esta
+                  carrera?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={() => handleAlertAction("close")}>
+                  Cancelar
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-green mt-2 sm:mt-0"
+                  onClick={() => handleAlertAction("myCareer")}
+                >
+                  Ir a mi carrera
+                </AlertDialogAction>
+                <Button
+                  variant="outline"
+                  onClick={() => handleAlertAction("addQuestion")}
+                >
+                  Publicar pregunta
+                </Button>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        );
+      case "aspirant":
+        return (
+          <AlertDialog open={showAlert} onOpenChange={setShowAlert}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Publicación no permitida</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Como aspirante, solo puedes publicar preguntas. ¿Quieres
+                  publicar una pregunta en esta carrera?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={() => handleAlertAction("close")}>
+                  Cancelar
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-green"
+                  onClick={() => handleAlertAction("addQuestion")}
+                >
+                  Publicar pregunta
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        );
+      default:
+        return null;
+    }
+  };
+
+  // If no session, don't render PostCard at all
+  if (!session?.user) return null;
+
   if (isDesktop) {
     return (
-      <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogTrigger asChild>
-          <PostCard onClick={() => setIsOpen(true)} />
-        </DialogTrigger>
-        <DialogContent className="h-svh max-h-xl mt-10 overflow-y-auto no-scrollbar">
-          <div className="mx-auto w-full max-w-md h-full flex flex-col">
-            <DialogHeader className="flex justify-between items-center border-b pb-2">
-              <DialogTitle className="flex-1">Nuevo Post</DialogTitle>
-              <Button
-                variant="green"
-                type="submit"
-                form="post-form"
-                className="ml-auto"
-              >
-                Publicar
-              </Button>
-            </DialogHeader>
-            <div className="flex-1 overflow-y-auto no-scrollbar">{content}</div>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <>
+        {renderAlert()}
+        <Dialog open={isOpen} onOpenChange={setIsOpen}>
+          <DialogTrigger asChild>
+            <PostCard onValidatedClick={handlePostCardClick} />
+          </DialogTrigger>
+          <DialogContent className="h-svh max-h-xl mt-10 overflow-y-auto no-scrollbar">
+            <div className="mx-auto w-full max-w-md h-full flex flex-col">
+              <DialogHeader className="flex justify-between items-center border-b pb-2">
+                <DialogTitle className="flex-1">Nuevo Post</DialogTitle>
+                <Button
+                  variant="green"
+                  type="submit"
+                  form="post-form"
+                  className="ml-auto"
+                >
+                  Publicar
+                </Button>
+              </DialogHeader>
+              <div className="flex-1 overflow-y-auto no-scrollbar">
+                {content}
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </>
     );
   }
 
   return (
-    <Drawer open={isOpen} onOpenChange={setIsOpen}>
-      <DrawerTrigger asChild>
-        <PostCard onClick={() => setIsOpen(true)} />
-      </DrawerTrigger>
-      <DrawerContent className="h-svh mt-10">
-        <div className="mx-auto w-full max-w-md h-full flex flex-col">
-          <DrawerHeader className="flex justify-between items-center border-b">
-            <DrawerTitle>Nuevo Post</DrawerTitle>
-            <Button variant="green" type="submit" form="post-form">
-              Publicar
-            </Button>
-          </DrawerHeader>
-          <div className="flex-1 overflow-y-auto no-scrollbar">{content}</div>
-        </div>
-      </DrawerContent>
-    </Drawer>
+    <>
+      {renderAlert()}
+      <Drawer open={isOpen} onOpenChange={setIsOpen}>
+        <DrawerTrigger asChild>
+          <PostCard onValidatedClick={handlePostCardClick} />
+        </DrawerTrigger>
+        <DrawerContent className="h-svh mt-10">
+          <div className="mx-auto w-full max-w-md h-full flex flex-col">
+            <DrawerHeader className="flex justify-between items-center border-b">
+              <DrawerTitle>Nuevo Post</DrawerTitle>
+              <Button variant="green" type="submit" form="post-form">
+                Publicar
+              </Button>
+            </DrawerHeader>
+            <div className="flex-1 overflow-y-auto no-scrollbar">{content}</div>
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </>
   );
 }

--- a/src/shared/components/PostForm/PostCard.tsx
+++ b/src/shared/components/PostForm/PostCard.tsx
@@ -1,32 +1,41 @@
 import { Card, CardContent } from "@/components/ui/card";
 import UserAvatar from "@/features/user/components/UserAvatar";
 import { useSession } from "next-auth/react";
+import { usePathname } from "next/navigation";
 
 interface PostCardProps {
-  onClick: () => void;
+  onValidatedClick: () => void;
 }
 
-export function PostCard({ onClick }: PostCardProps) {
+export function PostCard({ onValidatedClick }: PostCardProps) {
   const { data: session, status } = useSession();
+  const pathname = usePathname();
 
+  // Detailed skeleton loading state
   if (status === "loading") {
     return (
       <div className="my-4 px-4 sm:px-6 lg:px-8">
-        <Card className=" w-full mx-auto cursor-pointer hover:bg-accent/50 transition-colors shadow-none">
+        <Card className="w-full mx-auto cursor-pointer hover:bg-accent/50 transition-colors shadow-none">
           <CardContent className="p-4 py-6 flex items-center space-x-4">
-            <UserAvatar />
-            <div className="w-full h-6 bg-gray-200 rounded animate-pulse"></div>
+            <div className="w-12 h-12 bg-gray-300 rounded-full animate-pulse"></div>
+            <div className="flex-1 space-y-2">
+              <div className="h-4 bg-gray-300 rounded animate-pulse w-3/4"></div>
+              <div className="h-3 bg-gray-200 rounded animate-pulse w-1/2"></div>
+            </div>
           </CardContent>
         </Card>
       </div>
     );
   }
 
+  // If no session, don't render PostCard at all
+  if (!session?.user) return null;
+
   return (
     <div className="my-4 px-4 sm:px-6 lg:px-8">
       <Card
         className="w-full mx-auto cursor-pointer hover:bg-accent/50 transition-colors shadow-none"
-        onClick={onClick}
+        onClick={onValidatedClick}
       >
         <CardContent className="p-4 py-6">
           <div className="flex items-center space-x-4">

--- a/src/utils/postRestrictions.ts
+++ b/src/utils/postRestrictions.ts
@@ -1,0 +1,53 @@
+import { Session } from "next-auth";
+import { getUserData } from "@/shared/actions/User/getUserData";
+
+export async function canCreatePost(
+  session: Session | null,
+  postType: "TESTIMONY" | "QUESTION",
+  currentCareerSlug: string
+): Promise<{ allowed: boolean; alertType: "student" | "aspirant" | null }> {
+  // If no session, always return aspirant alert
+  if (!session?.user) {
+    return { allowed: false, alertType: "aspirant" };
+  }
+  
+  // Student-specific logic
+  if (session.user.role === "STUDENT") {
+    // Allow students to post questions anywhere
+    if (postType === "QUESTION") {
+      return { allowed: true, alertType: null };
+    }
+
+    // For testimonies, check if it's their own career
+    if (postType === "TESTIMONY") {
+      // Fetch user data to get the most up-to-date career information
+      const userId = session.user.id;
+      if (!userId) {
+        return { allowed: false, alertType: "student" };
+      }
+      const userData = await getUserData(userId);
+      
+      // Check if user has a career and it matches the current career
+      if (userData.career?.slug === currentCareerSlug) {
+        return { allowed: true, alertType: null };
+      }
+      
+      // Show alert if trying to post testimony in a different career
+      return { allowed: false, alertType: "student" };
+    }
+  }
+
+  // Aspirant-specific logic
+  if (session.user.role === "ASPIRANT") {
+    // Aspirants can only post questions
+    if (postType === "TESTIMONY") {
+      return { allowed: false, alertType: "aspirant" };
+    }
+    
+    // Allow aspirants to post questions in any career
+    return { allowed: true, alertType: null };
+  }
+
+  // Default case - disallow posting
+  return { allowed: false, alertType: null };
+}


### PR DESCRIPTION
- Modify `canCreatePost` function to be async and use `getUserData`
- Implement stricter posting rules for students and aspirants
- Update `NewPost` component to handle async post creation restrictions
- Ensure students can only post testimonies in their own career
- Allow students to post questions in any career
- Restrict aspirants from posting testimonies
- Allow aspirants to post questions in any career